### PR TITLE
feat: add optional command timeout

### DIFF
--- a/nix/checks/systemd-vaultd-test.nix
+++ b/nix/checks/systemd-vaultd-test.nix
@@ -94,6 +94,7 @@
     machine.wait_for_unit("vault.service")
     machine.wait_for_open_port(8200)
     machine.wait_for_unit("setup-vault-agent-approle.service")
+    machine.wait_for_unit("vault-agent-default.service")
 
     out = machine.wait_until_succeeds("grep -q bar /tmp/service1")
 


### PR DESCRIPTION
Some template command can last longer than the default 30s. Add option to override default timeout.

Define template commands using `exec` as `command` is deprecated. (https://developer.hashicorp.com/vault/docs/agent/template#command)