### PR TITLE
Fix buildGoModule vendor hash attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 pkgs.buildGoModule {
   name = "systemd-vaultd";
   src = ./.;
-  vendorSha256 = null;
+  vendorHash = null;
   meta = with pkgs.lib; {
     description = "A proxy for secrets between systemd services and vault";
     homepage = "https://github.com/numtide/systemd-vaultd";


### PR DESCRIPTION
We cannot use the `vendorSha256` attribute in the `buildGoModule` function anymore.