### PR TITLE
fix: add missing dependency on systemd-vaultd socket

### DIFF
--- a/nix/modules/vault-secrets.nix
+++ b/nix/modules/vault-secrets.nix
@@ -175,6 +175,8 @@ in
               Before=${service}.service
               BindsTo=${service}.service
               StopPropagatedFrom=${service}.service
+              After=systemd-vaultd.socket
+              Requires=systemd-vaultd.socket
 
               [Service]
               Type=oneshot


### PR DESCRIPTION
The systemd service unit file generate environment file requests secrets from the systemd-vaultd socket.

We make sure this socket is ready before starting the service.