### PR TITLE
Add jq to devshell's deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
               python3.pkgs.mypy
 
               golangci-lint
+              jq
               vault
               systemd
               hivemind


### PR DESCRIPTION
Fixes the following error:

```
$ just up
<..>
vault-agent     | ./tests/setup-vault: line 24: jq: command not found
<..>
```