### PR TITLE
ci: auto-merge dependabot updates and require buildbot checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -30,7 +30,7 @@ repository:
   has_downloads: false
 
   # Updates the default branch for this repository.
-  default_branch: master
+  default_branch: main
 
   # Either `true` to allow squash-merging pull requests, or `false` to prevent
   # squash-merging.
@@ -104,7 +104,7 @@ teams:
     permission: maintain
 
 branches:
-  - name: master
+  - name: main
     # https://docs.github.com/en/rest/reference/repos#update-branch-protection
     # Branch Protection settings. Set to null to disable
     protection:
@@ -125,13 +125,9 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: [ "bors" ]
+        contexts: [ "buildbot/nix-build", "buildbot/nix-eval" ]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
-      # Disabled for bors to work
       required_linear_history: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions:
-        apps: [ "bors" "github-actions[bot]" ]
-        users: []
-        teams: []
+      restrictions: null

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,14 @@
+name: Auto Merge Dependency Updates
+on:
+  - pull_request_target
+jobs:
+  auto-merge-dependency-updates:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: "auto-merge:${{ github.head_ref }}"
+      cancel-in-progress: true
+    steps:
+      - uses: Mic92/auto-merge@main


### PR DESCRIPTION
Add the auto-merge workflow so dependabot PRs merge automatically once CI passes. Update repo settings to require the buildbot/nix-build and buildbot/nix-eval checks on main instead of the retired bors setup.