### PR TITLE
README: add example-driven NixOS usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,140 @@ files: `systemd-vaultd.service`, `systemd-vaultd.socket`:
 make install
 ```
 
+## Usage on NixOS
+
+systemd-vaultd ships two NixOS modules as flake outputs:
+
+- `nixosModules.systemdVaultd`: the systemd-vaultd socket/daemon plus a
+  `systemd.services.<name>.vault` interface to declare secrets per service.
+- `nixosModules.vaultAgent`: a small module to run one or more
+  `vault agent` (OpenBao by default) instances via `services.vault.agents`.
+
+### 1. Add the flake input and import the modules
+
+```nix
+{
+  inputs.systemd-vaultd.url = "github:numtide/systemd-vaultd";
+
+  outputs = { nixpkgs, systemd-vaultd, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        systemd-vaultd.nixosModules.systemdVaultd
+        systemd-vaultd.nixosModules.vaultAgent
+        ./configuration.nix
+      ];
+    };
+  };
+}
+```
+
+### 2. Configure a vault agent
+
+The agent authenticates against your Vault/OpenBao server and renders the
+secret templates. Any [vault agent configuration](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent)
+can be passed via `settings`:
+
+```nix
+{
+  services.vault.agents.default = {
+    # package = pkgs.openbao; # default; set to pkgs.vault for HashiCorp Vault
+    settings = {
+      vault.address = "https://vault.example.com:8200";
+      auto_auth.method = [
+        {
+          type = "approle";
+          config = {
+            role_id_file_path = "/var/lib/vault-agent/roleID";
+            secret_id_file_path = "/var/lib/vault-agent/secretID";
+            remove_secret_id_file_after_reading = false;
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+### 3. Declare secrets on your systemd services
+
+Secrets are declared directly on the consuming service. systemd-vaultd wires
+up `LoadCredential` for you and blocks service startup until the agent has
+rendered the secret:
+
+```nix
+{
+  systemd.services.myservice = {
+    wantedBy = [ "multi-user.target" ];
+    script = ''
+      # secrets show up as systemd credentials
+      cat "$CREDENTIALS_DIRECTORY/foo"
+    '';
+
+    vault = {
+      # vault agent template rendering a JSON map; each key becomes a credential
+      template = ''
+        {{ with secret "secret/my-secret" }}{{ .Data.data | toJSON }}{{ end }}
+      '';
+      secrets.foo = { };
+    };
+  };
+}
+```
+
+Binary secrets can be stored base64-encoded with a `base64:` prefix and are
+decoded before being served, e.g.
+`vault kv put secret/my-secret cert="base64:$(base64 < cert.der)"`.
+
+### Environment variables instead of files
+
+For services that expect secrets in environment variables, use
+`environmentTemplate`:
+
+```nix
+{
+  systemd.services.myservice = {
+    script = ''
+      echo "the secret is $SECRET_ENV"
+    '';
+
+    vault.environmentTemplate = ''
+      {{ with secret "secret/my-secret" }}
+      SECRET_ENV={{ .Data.data.foo }}
+      {{ end }}
+    '';
+  };
+}
+```
+
+### Reacting to secret changes
+
+By default a service is reloaded (or restarted if it has no reload action)
+when its secrets change (`vault.changeAction = "reload-or-restart"`). Set it
+to `"restart"` or `"none"` to change that behavior.
+
+Since systemd only reads `LoadCredential` at service start, reloading alone
+does not refresh credentials. The bundled `systemd-vaultd-update-secrets`
+helper can copy the rendered secrets into a directory owned by the service on
+reload:
+
+```nix
+{
+  systemd.services.myservice = {
+    serviceConfig = {
+      RuntimeDirectory = "myservice";
+      ExecReload = "+${config.services.systemd-vaultd.package}/bin/systemd-vaultd-update-secrets /run/myservice/secrets";
+    };
+    preStart = ''
+      cp -r "$CREDENTIALS_DIRECTORY" /run/myservice/secrets
+    '';
+  };
+}
+```
+
+A complete end-to-end example (agent + secrets + reload handling) lives in
+[nix/checks/systemd-vaultd-test.nix](nix/checks/systemd-vaultd-test.nix).
+
 ## Known limitations
 
 systemd's LoadCredential option will not update credentials if a service is


### PR DESCRIPTION
Document the flake modules, vault agent setup, per-service secret declaration, environment templates and reload handling with concrete examples. Closes #64.